### PR TITLE
Correct formatting around 'To run' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Any errors on the secondary response are ignored and do not interfere with the p
 
 # To run
 
-On your local host, run:
+On your *local host*, run:
 
-````
+```
 PRIMARY_UPSTREAM=http://content-store.dev.gov.uk SECONDARY_UPSTREAM=http://content-store-on-postgresql.dev.gov.uk bundle exec rackup config.rb -p4567 
 ```
 


### PR DESCRIPTION
Before:
![image](https://github.com/alphagov/content-store-proxy/assets/134501/baa72c20-bcd1-458b-8df6-2b2688e02fbb)

After:
![image](https://github.com/alphagov/content-store-proxy/assets/134501/857a8d58-dede-4ca9-91e3-47be77a5743b)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
