### PR TITLE
Add Dockerfile for k8s deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
+
+FROM $builder_image AS builder
+
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
+RUN bundle install
+COPY . .
+RUN bootsnap precompile --gemfile .
+
+
+FROM $base_image
+
+ENV GOVUK_APP_NAME=content-store-proxy
+
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
+
+USER app
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "bootsnap", require: false
 gem "faraday", ">= 1.5.1"
 gem "logger"
 gem "rack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bootsnap (1.16.0)
+      msgpack (~> 1.2)
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -25,6 +27,7 @@ GEM
     json (2.6.3)
     logger (1.5.3)
     minitest (5.18.0)
+    msgpack (1.7.1)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
@@ -116,6 +119,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootsnap
   byebug
   faraday (>= 1.5.1)
   logger


### PR DESCRIPTION
Add Dockerfile to allow this app to be built via CI and deployed onto Kubernetes

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
