### PR TITLE
Log different_keys when both responses are JSON, format logs as JSON

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,7 +31,9 @@ class ContentStoreProxyApp < Sinatra::Base
     primary_response, secondary_response = RequestForwarder.mirror_to(@primary, @secondary, request)
 
     # log comparison of the two responses
-    logger.info("stats: #{ResponseComparator.compare(primary_response, secondary_response)}")
+    comparison = ResponseComparator.compare(primary_response, secondary_response)
+    method = comparison[:first_difference].empty? ? :info : :warn
+    logger.send(method, "path: #{request.path}, stats: #{comparison}")
 
     [primary_response.status, primary_response.headers, primary_response.body]
   end

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ class ContentStoreProxyApp < Sinatra::Base
     # log comparison of the two responses
     comparison = ResponseComparator.compare(primary_response, secondary_response)
     method = comparison[:first_difference].empty? ? :info : :warn
-    logger.send(method, "path: #{request.path}, stats: #{comparison}")
+    logger.send(method, { path: request.path, stats: comparison }.to_json)
 
     [primary_response.status, primary_response.headers, primary_response.body]
   end

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -6,6 +6,7 @@ class ResponseComparator
       primary_response: response_stats(primary_response),
       secondary_response: response_stats(secondary_response),
       first_difference: first_difference(primary_response.body, secondary_response.body),
+      different_keys: different_keys(primary_response.body, secondary_response.body),
     }
   end
 
@@ -18,13 +19,19 @@ class ResponseComparator
   end
 
   def self.first_difference(string1, string2)
-    i = 0
-    i += 1 while string1[i] == string2[i] && i < string1.size
-
-    if i < string1.size || i < string2.size
-      { position: i, context: [string1[i - 5..i + 5], string2[i - 5..i + 5]] }
-    else
+    if string1 == string2
       {}
+    else
+      i = (0...string1.size).find { |j| string1[j] != string2[j] } || string1.size
+      { position: i, context: [string1[i - 5..i + 5], string2[i - 5..i + 5]] }
     end
+  end
+
+  def self.different_keys(json_hash1, json_hash2)
+    obj1 = JSON.parse(json_hash1)
+    obj2 = JSON.parse(json_hash2)
+    (obj1.keys + obj2.keys).uniq.reject { |k| obj1[k] == obj2[k] }
+  rescue JSON::ParserError
+    "N/A"
   end
 end

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe ResponseComparator do
     end
   end
 
+  describe ".different_keys" do
+    context "when given two strings that are both JSON" do
+      let(:string1) { { a: "a", b: "b", c: %w[c1 c2] }.to_json }
+      let(:string2) { { a: "a", b: "different b", c: ["c1", "different c2"] }.to_json }
+
+      it "returns an array of the keys with different values" do
+        expect(described_class.different_keys(string1, string2)).to eq(%w[b c])
+      end
+    end
+
+    context "when given two strings that are not both JSON" do
+      let(:string1) { "not json" }
+      let(:string2) { "not json either" }
+
+      it "does not error" do
+        expect { described_class.different_keys(string1, string2) }.not_to raise_error
+      end
+
+      it "returns N/A" do
+        expect(described_class.different_keys(string1, string2)).to eq("N/A")
+      end
+    end
+  end
+
   describe ".compare" do
     context "when given a primary_response and a secondary_response" do
       let(:primary_response) do
@@ -137,6 +161,18 @@ RSpec.describe ResponseComparator do
 
           it "is set to the response_stats for the secondary_response" do
             expect(secondary_response_key).to eq("mock secondary response stats")
+          end
+        end
+
+        describe "the different_keys key" do
+          let(:different_keys) { %w[key1 key2] }
+
+          before do
+            allow(described_class).to receive(:different_keys).and_return(different_keys)
+          end
+
+          it "is set to the return value of different_keys" do
+            expect(return_value[:different_keys]).to eq(different_keys)
           end
         end
       end


### PR DESCRIPTION
To help identify the source of any differences between the primary and secondary responses:

- add the request path to each log line
- when the responses are different, log at `WARN` level
- when both responses are valid JSON hashes (as we would expect from `content-store` API requests), add a `different_keys` element to the logged comparison. 
- format log messages as actual JSON, not Ruby-serialized Hash 

Example output:

When both responses are identical:
```
I, [2023-07-04T08:56:58.227581 #21]  INFO -- : {"path":"/api/content/","stats":{"primary_response":{"status":200,"body_size":22949,"time":0.030518413},"secondary_response":{"status":200,"body_size":22949,"time":0.025518609},"first_difference":{},"different_keys":[]}}
```

When they're not:
```
W, [2023-07-04T09:59:14.144859 #112048]  WARN -- : {"path":"/foo","stats":{"primary_response":{"status":200,"body_size":21,"time":0.000908599},"secondary_response":{"status":201,"body_size":23,"time":0.000786372},"first_difference":{"position":0,"context":["",""]},"different_keys":"N/A"}}
```

Trello cards: [1](https://trello.com/c/1gljPBwl/720-find-out-why-the-contentitem-links-field-differs-between-mongo-pg), [2](https://trello.com/c/xeJcwf6w/707-deploy-content-store-proxy-in-integration-for-the-draft-content-store)
This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
