### PR TITLE
Stop dropping the CONTENT_TYPE header when forwarding requests

### DIFF
--- a/lib/request_forwarder.rb
+++ b/lib/request_forwarder.rb
@@ -69,9 +69,17 @@ class RequestForwarder
     end
   end
 
+  def self.copy_header?(name)
+    # Content-type doesn't come through with a HTTP_ prefix
+    # (see https://github.com/rack/rack/issues/1311)
+    # so we have to explicitly include it
+    name == "CONTENT_TYPE" ||
+      (name.start_with?("HTTP_") && name != "HTTP_HOST")
+  end
+
   def self.headers_from(incoming_request)
-    incoming_request.env.select { |name, _| name.start_with?("HTTP_") && name != "HTTP_HOST" }.map { |header, value|
-      [header[5..].split("_").map(&:capitalize).join("-"), value]
+    incoming_request.env.select { |name, _| copy_header?(name) }.map { |header, value|
+      [header.sub(/^HTTP_/, "").split("_").map(&:capitalize).join("-"), value]
     }.compact.to_h
   end
 end


### PR DESCRIPTION
RequestForwarder copies headers by looking for HTTP_ prefixes in the Rack-parsed environment given to each request, and explicitly hacking the CONTENT_LENGTH (which is not prefixed) to align with the transfer encoding of the body.

However, CONTENT_TYPE is also a special case and is not prefixed (see https://github.com/rack/rack/issues/1311), therefore must be explicitly checked for. As a result, content-store-proxy was not passing the content type through, and this caused issues for POST requests. In the absence of an explicit JSON content-type, Rails was treating the JSON in the body as form-encoded, and this led to [problems with URLs embedded in the body content](https://trello.com/c/LTCo5fnV/802-travel-advice-alert-status-not-updating) - ampersands were getting Unicode-escaped to \u0026, and the whole request was being dropped by content-store with a HTTP 400 Bad Request.

This PR fixes the issue by explicitly checking for a given CONTENT_TYPE and passing it through.
H/T @richardTowers for the hypothesis

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
