### PR TITLE
Stop warning about small differences in updated_at timestamps

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,16 +35,30 @@ class ContentStoreProxyApp < Sinatra::Base
   end
 
   def log_comparison(comparison)
-    level = comparison[:first_difference].empty? ? :info : :warn
     line = {
       timestamp: Time.now.utc.iso8601,
-      level:,
+      level: log_level(comparison),
       method: env["REQUEST_METHOD"],
       path: request.path,
       query_string: env["QUERY_STRING"],
       stats: comparison,
     }
     puts line.to_json
+  end
+
+  def log_level(comparison)
+    if (comparison[:different_keys].empty? || comparison[:different_keys] == "N/A") &&
+        matches?(comparison, :status) &&
+        matches?(comparison, :body_size)
+      :info
+    else
+      :warn
+    end
+  end
+
+  def matches?(comparison, field)
+    comparison.fetch(:stats, {}).fetch(:primary_response, {}).fetch(field, nil) ==
+      comparison.fetch(:stats, {}).fetch(:secondary_response, {}).fetch(field, nil)
   end
 
   route :get, :put, :patch, :post, :delete, :head, :options, "/*" do

--- a/app.rb
+++ b/app.rb
@@ -57,8 +57,7 @@ class ContentStoreProxyApp < Sinatra::Base
   end
 
   def matches?(comparison, field)
-    comparison.fetch(:stats, {}).fetch(:primary_response, {}).fetch(field, nil) ==
-      comparison.fetch(:stats, {}).fetch(:secondary_response, {}).fetch(field, nil)
+    comparison.dig(:stats, :primary_response, field) == comparison.dig(:stats, :secondary_response, field)
   end
 
   route :get, :put, :patch, :post, :delete, :head, :options, "/*" do


### PR DESCRIPTION
The proxy will warn about any differences in the JSON returned between the Postgres vs Mongo content-stores. This is fine, but the overwhelming majority of warnings we see are due to single-second differences in the `updated_at` timestamps:

![image](https://github.com/alphagov/content-store-proxy/assets/134501/bbb60cc6-e58a-4f12-99c3-c38c72832cd6)

Example segment from one of those rows:
```
"first_difference":{"position":209331,"context":[":19:17Z\",\"w",":19:18Z\",\"w"]},"different_keys":["updated_at"]}
```

These single-second differences are nothing to worry about, as `updated_at` is set by the ORM layer on write, and occasionally the two DB writes will complete either side of a second boundary as they run in parallel.

So this PR detects that particular case, and ignores it.  ([Trello card](https://trello.com/c/kV5IRrPw/818-stop-the-content-store-proxy-warning-us-about-single-second-differences-in-updatedat-timestamps))

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
