### PR TITLE
Add time spend comparing responses

### DIFF
--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -9,11 +9,13 @@ class ResponseComparator
   MAX_UPDATED_AT_DIFFERENCE = 2
 
   def self.compare(primary_response, secondary_response)
+    start = Time.now
     {
       primary_response: response_stats(primary_response),
       secondary_response: response_stats(secondary_response),
       first_difference: first_difference(primary_response.body, secondary_response.body),
       different_keys: different_keys(primary_response.body, secondary_response.body),
+      comparison_time_seconds: Time.now - start,
     }
   end
 

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "faraday"
 require "response_comparator"
 
 RSpec.describe ResponseComparator do
@@ -171,6 +172,8 @@ RSpec.describe ResponseComparator do
         before do
           allow(described_class).to receive(:response_stats).with(primary_response).and_return("mock primary response stats")
           allow(described_class).to receive(:response_stats).with(secondary_response).and_return("mock secondary response stats")
+          allow(described_class).to receive(:different_keys).and_return([])
+          allow(described_class).to receive(:first_difference).and_return("N/A")
         end
 
         it "is a Hash" do
@@ -206,6 +209,12 @@ RSpec.describe ResponseComparator do
 
           it "is set to the return value of different_keys" do
             expect(return_value[:different_keys]).to eq(different_keys)
+          end
+        end
+
+        describe "the response_comparison_seconds key" do
+          it "is a non-zero float" do
+            expect(return_value[:comparison_time_seconds]).to be > 0.00
           end
         end
       end


### PR DESCRIPTION
After rolling-out to production recently, we found that CPU usage increased dramatically - far more than you would expect from a simple proxy - and response times rose to multiple seconds, despite the upstream response times (ie. the actual content-stores) remaining normal. 

We suspect the extra time may be taken in parsing & comparing the responses, as that's the only part of the process that would be CPU-intensive. In local testing, that comparison only accounts for 1% of the total response time, but we suspect this isn't the case in a much busier environment (production) on Kubernetes, with many more processes competing for their share of the CPU. Details in this [Trello card](https://trello.com/c/krmNL5Z9/855-benchmark-the-cpu-overhead-of-the-content-store-proxy).

Hence this PR adds a rudimentary figure for the elapsed-time taken to compare the responses, so that we can test this hypothesis

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
