### PR TITLE
Fix unable-to-install-psych error in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ ARG ruby_version=3.1.2
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
-
 FROM $builder_image AS builder
+# Need this as govuk_app_config 9.4 requires railties 5.1, which
+# ultimately installs psych 5.1, which needs libyaml-dev
+# Only an issue for this app because it's not Rails. 
+RUN install_packages libyaml-dev
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./


### PR DESCRIPTION
After merging #40, the CD action was [unable to build the container image](https://github.com/alphagov/content-store-proxy/actions/runs/6429974014/job/17460050965#step:7:465). It failed on installing the `govuk_app_config` gem due to its indirect reliance on psych 5:
```
#11 22.54 In Gemfile:
#11 22.54   govuk_app_config was resolved to 9.4.0, which depends on
#11 22.54     sentry-rails was resolved to 5.11.0, which depends on
#11 22.54       railties was resolved to 7.1.0, which depends on
#11 22.54         irb was resolved to 1.8.1, which depends on
#11 22.54           rdoc was resolved to 6.5.0, which depends on
#11 22.54             psych
```
We found two possible solutions:
1. add `gem "railties", "<=7.0.8"` to the Gemfile, or
2. install the `libyaml-dev` package as part of the Dockerfile build

The second seemed a better solution. It's only been a problem for this app and not other GOV.UK apps so far, because it's not Rails.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
