### PR TITLE
Only fully compare a given sample percentage of responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,26 @@ It will forward all incoming requests to the given `PRIMARY_UPSTREAM` and `SECON
 > curl http://localhost:4567/api/content/government/ministers
 ...
 
-[2023-05-05T14:37:49.086053 #1430397]  INFO -- : stats: {:primary_response=>{:status=>200, :body_size=>3343568, :time=>0.541455142}, :secondary_response=>{:status=>200, :body_size=>532778, :time=>0.128399933}, :first_difference=>{:position=>187, :context=>["4.000+00:00", "4.000Z\",\"lo"]}}
+{"timestamp":"2023-10-05T12:00:56Z","level":"info","method":"GET","path":"/api/content/government/publications/care-act-statutory-guidance/care-and-support-statutory-guidance","query_string":"","stats":{"primary_response":{"status":200,"body_size":1773132,"time":0.095294816},"secondary_response":{"status":200,"body_size":1773132,"time":0.101621268},"first_difference":"N/A","different_keys":"N/A"}}
 
 ```
 
-In this line, `:context` gives you the 5 characters either side of the first difference detected in the two response bodies. This has always been (so far) a difference in UTC timezone representation between MongoDB and PostgreSQL, but it's there just for info in case anything else comes up.
-
 Any errors on the secondary response are ignored and do not interfere with the primary response.
+
+## Detailed Response Comparison and CPU-load
+
+Note: comparing the responses is CPU-intensive, and so must be used with care on highly-contended environments like production. For a given percentage of requests, a full comparison will be run which will populate the `first_difference` and `different_keys` keys. The percentage is controlled by the environment variable `COMPARISON_SAMPLE_PCT`. The default value for this is `0` - to compare, say, one in ten requests you would supply `COMPARISON_SAMPLE_PCT=10`.
+
+The full comparison looks like this:
+
+```
+{"timestamp":"2023-10-06T09:50:42Z","level":"warn","method":"GET","path":"/content/foreign-travel-advice","query_string":"","stats":{"primary_response":{"status":200,"body_size":327029,"time":0.180271175},"secondary_response":{"status":200,"body_size":327018,"time":0.132149683},"first_difference":{"position":181900,"context":["vice/czech-","vice/gabon\""]},"different_keys":["links","updated_at"]}}
+```
+
+`first_difference` gives the index of the first character which differs between the two responses, and the five characters either side of that position in each response.
+`different_keys` gives the names of all top-level keys in the two JSON structures which have different values.
+
+
 
 # To run
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mirroring proxy to enable dual-running of MongoDB &amp; PostgreSQL versions of c
 It will forward all incoming requests to the given `PRIMARY_UPSTREAM` and `SECONDARY_UPSTREAM` URLs in parallel, and return the primary response. Once both upstream responses have been received, it will log a line comparing the two, e.g.
 
 ```
-> curl http://localhost:4567/api/content/government/ministers
+> curl http://localhost:4567/api/content/government/publications/care-act-statutory-guidance/care-and-support-statutory-guidance
 ...
 
 {"timestamp":"2023-10-05T12:00:56Z","level":"info","method":"GET","path":"/api/content/government/publications/care-act-statutory-guidance/care-and-support-statutory-guidance","query_string":"","stats":{"primary_response":{"status":200,"body_size":1773132,"time":0.095294816},"secondary_response":{"status":200,"body_size":1773132,"time":0.101621268},"first_difference":"N/A","different_keys":"N/A"}}

--- a/app.rb
+++ b/app.rb
@@ -22,8 +22,10 @@ class ContentStoreProxyApp < Sinatra::Base
   def forward_request(request)
     primary_response, secondary_response = RequestForwarder.mirror_to(@primary, @secondary, request)
 
-    # log comparison of the two responses
-    comparison_type = rand(100) <= @comparison_sample_pct ? :quick : :full
+    # Log comparison of the two responses, but only the given percentage of them get the full comparison.
+    # This is to prevent the issue seen under full production load, where the CPU usage of the proxy app
+    # maxes out its limit (details: )
+    comparison_type = rand(100) < @comparison_sample_pct ? :quick : :full
     log_comparison ResponseComparator.compare(primary_response, secondary_response, comparison_type)
     [primary_response.status, primary_response.headers, primary_response.body]
   end

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -8,14 +8,27 @@ class ResponseComparator
   # complete either side of a second boundary as they run in parallel.
   MAX_UPDATED_AT_DIFFERENCE = 2
 
-  def self.compare(primary_response, secondary_response)
+  def self.compare(primary_response, secondary_response, type = :quick)
     start = Time.now
+    comparison = quick_comparison(primary_response, secondary_response)
+    comparison.merge!(differences(primary_response, secondary_response)) if type == :full
+    comparison[:comparison_time_seconds] = Time.now - start
+    comparison
+  end
+
+  def self.quick_comparison(primary_response, secondary_response)
     {
       primary_response: response_stats(primary_response),
       secondary_response: response_stats(secondary_response),
+      first_difference: "N/A",
+      different_keys: "N/A",
+    }
+  end
+
+  def self.differences(primary_response, secondary_response)
+    {
       first_difference: first_difference(primary_response.body, secondary_response.body),
       different_keys: different_keys(primary_response.body, secondary_response.body),
-      comparison_time_seconds: Time.now - start,
     }
   end
 

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "faraday"
+
 require "spec_helper"
 require "faraday"
 require "response_comparator"
@@ -200,15 +202,67 @@ RSpec.describe ResponseComparator do
           end
         end
 
-        describe "the different_keys key" do
-          let(:different_keys) { %w[key1 key2] }
+        context "when given a type of :quick" do
+          let(:return_value) { described_class.compare(primary_response, secondary_response, :quick) }
 
-          before do
-            allow(described_class).to receive(:different_keys).and_return(different_keys)
+          it "does not call different_keys" do
+            expect(described_class).not_to receive(:different_keys)
+            return_value
           end
 
-          it "is set to the return value of different_keys" do
-            expect(return_value[:different_keys]).to eq(different_keys)
+          describe "the different_keys key" do
+            it "is 'N/A'" do
+              expect(return_value[:different_keys]).to eq("N/A")
+            end
+          end
+
+          it "does not call first_difference" do
+            expect(described_class).not_to receive(:first_difference)
+            return_value
+          end
+
+          describe "the first_difference key" do
+            it "is 'N/A'" do
+              expect(return_value[:first_difference]).to eq("N/A")
+            end
+          end
+        end
+
+        context "when given a type of :full" do
+          let(:return_value) { described_class.compare(primary_response, secondary_response, :full) }
+
+          it "calls different_keys" do
+            expect(described_class).to receive(:different_keys)
+            return_value
+          end
+
+          describe "the different_keys key" do
+            let(:different_keys) { %w[key1 key2] }
+
+            before do
+              allow(described_class).to receive(:different_keys).and_return(different_keys)
+            end
+
+            it "is set to the return value of different_keys" do
+              expect(return_value[:different_keys]).to eq(different_keys)
+            end
+          end
+
+          it "calls first_difference" do
+            expect(described_class).to receive(:first_difference)
+            return_value
+          end
+
+          describe "the first_difference key" do
+            let(:first_difference) { "first diff" }
+
+            before do
+              allow(described_class).to receive(:first_difference).and_return(first_difference)
+            end
+
+            it "is set to the return value of first_difference" do
+              expect(return_value[:first_difference]).to eq(first_difference)
+            end
           end
         end
 

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -3,7 +3,6 @@
 require "faraday"
 
 require "spec_helper"
-require "faraday"
 require "response_comparator"
 
 RSpec.describe ResponseComparator do


### PR DESCRIPTION
After a quickly-reverted rollout to production found that the proxy was maxing-out its' CPU limits (see full details in the [Trello card](https://trello.com/c/krmNL5Z9/855-benchmark-the-cpu-overhead-of-the-content-store-proxy)) we decided to reduce the overhead by only running the full CPU-intensive response comparison on a configurable percentage of requests.

This PR introduces the `COMPARISON_SAMPLE_PCT` env var, which by default is zero - so unless configured otherwise, no requests will be fully compared. It also updates the README to explain this change, its reasoning, and what the log lines will look for requests which are and are not fully compared. ([Trello card](https://trello.com/c/gF3XSEqC/864-reduce-the-cpu-load-imposed-by-content-store-proxy) for this work)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
