### PR TITLE
factor out the calculation of comparison_type to a separate method

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -24,10 +24,17 @@ class ContentStoreProxyApp < Sinatra::Base
 
     # Log comparison of the two responses, but only the given percentage of them get the full comparison.
     # This is to prevent the issue seen under full production load, where the CPU usage of the proxy app
-    # maxes out its limit (details: )
-    comparison_type = rand(100) < @comparison_sample_pct ? :quick : :full
+    # maxes out its limit
     log_comparison ResponseComparator.compare(primary_response, secondary_response, comparison_type)
     [primary_response.status, primary_response.headers, primary_response.body]
+  end
+
+  def comparison_type
+    if @comparison_sample_pct == 100 || rand(99) < @comparison_sample_pct
+      :full
+    else
+      :quick
+    end
   end
 
   get "/healthcheck/live" do


### PR DESCRIPTION
Factor-out the calculation introduced by #43 to a separate method and correct the central comparison - the `:quick` and `:full` were the wrong way round in the ternary operator. It's clearer this way too.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
