### PR TITLE
Don't log first_difference & different_keys fields at all when only doing a quick comparison

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,7 +50,7 @@ class ContentStoreProxyApp < Sinatra::Base
   end
 
   def log_level(comparison)
-    if (comparison[:different_keys].empty? || comparison[:different_keys] == "N/A") &&
+    if (comparison[:different_keys].nil? || comparison[:different_keys] == "N/A") &&
         matches?(comparison, :status) &&
         matches?(comparison, :body_size)
       :info

--- a/app.rb
+++ b/app.rb
@@ -25,7 +25,7 @@ class ContentStoreProxyApp < Sinatra::Base
     # Log comparison of the two responses, but only the given percentage of them get the full comparison.
     # This is to prevent the issue seen under full production load, where the CPU usage of the proxy app
     # maxes out its limit
-    log_comparison ResponseComparator.compare(primary_response, secondary_response, @comparison_sample_pct)
+    log_comparison ResponseComparator.new(primary_response, secondary_response, @comparison_sample_pct).compare
     [primary_response.status, primary_response.headers, primary_response.body]
   end
 

--- a/app.rb
+++ b/app.rb
@@ -25,16 +25,8 @@ class ContentStoreProxyApp < Sinatra::Base
     # Log comparison of the two responses, but only the given percentage of them get the full comparison.
     # This is to prevent the issue seen under full production load, where the CPU usage of the proxy app
     # maxes out its limit
-    log_comparison ResponseComparator.compare(primary_response, secondary_response, comparison_type)
+    log_comparison ResponseComparator.compare(primary_response, secondary_response, @comparison_sample_pct)
     [primary_response.status, primary_response.headers, primary_response.body]
-  end
-
-  def comparison_type
-    if @comparison_sample_pct == 100 || rand(99) < @comparison_sample_pct
-      :full
-    else
-      :quick
-    end
   end
 
   get "/healthcheck/live" do

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -26,7 +26,8 @@ class ResponseComparator
   end
 
   def self.full_comparison?(comparison, full_pct)
-    r = rand(99)
+    srand
+    r = Random.rand(99)
     full = (full_pct == 100 || r < full_pct)
     comparison.merge!(sample_percent: full_pct, r:)
     full

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -8,10 +8,10 @@ class ResponseComparator
   # complete either side of a second boundary as they run in parallel.
   MAX_UPDATED_AT_DIFFERENCE = 2
 
-  def self.compare(primary_response, secondary_response, type = :quick)
+  def self.compare(primary_response, secondary_response, full_comparison_pct = 0)
     start = Time.now
     comparison = quick_comparison(primary_response, secondary_response)
-    comparison.merge!(differences(primary_response, secondary_response)) if type == :full
+    comparison.merge!(differences(primary_response, secondary_response)) if full_comparison?(comparison, full_comparison_pct)
     comparison[:comparison_time_seconds] = Time.now - start
     comparison
   end
@@ -23,6 +23,13 @@ class ResponseComparator
       first_difference: "N/A",
       different_keys: "N/A",
     }
+  end
+
+  def self.full_comparison?(comparison, full_pct)
+    r = rand(99)
+    full = (full_pct == 100 || r < full_pct)
+    comparison.merge!(sample_percent: full_pct, r:)
+    full
   end
 
   def self.differences(primary_response, secondary_response)

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -32,10 +32,9 @@ class ResponseComparator
   end
 
   def full_comparison?(comparison, full_pct)
-    r = Random.rand(99)
-    full = (full_pct == 100 || r < full_pct)
+    r = Random.rand(100)
     comparison.merge!(sample_percent: full_pct, r:)
-    full
+    (r < full_pct)
   end
 
   def differences

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -28,8 +28,6 @@ class ResponseComparator
     {
       primary_response: response_stats(@primary_response),
       secondary_response: response_stats(@secondary_response),
-      first_difference: "N/A",
-      different_keys: "N/A",
     }
   end
 

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe ResponseComparator do
 
     context "when the random number from 0-99 is less than the given full_pct" do
       before do
-        allow(Random).to receive(:rand).with(99).and_return(5)
+        allow(Random).to receive(:rand).with(100).and_return(5)
       end
 
       it "returns true" do
@@ -277,7 +277,7 @@ RSpec.describe ResponseComparator do
 
     context "when the random number from 0-99 is greater than the given full_pct" do
       before do
-        allow(Random).to receive(:rand).with(99).and_return(25)
+        allow(Random).to receive(:rand).with(100).and_return(25)
       end
 
       it "returns false" do
@@ -286,7 +286,7 @@ RSpec.describe ResponseComparator do
     end
 
     it "adds :r and :sample_percent keys to the given comparison" do
-      allow(Random).to receive(:rand).with(99).and_return(26)
+      allow(Random).to receive(:rand).with(100).and_return(26)
       obj = {}
       comparator.full_comparison?(obj, 10)
       expect(obj[:r]).to eq(26)

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe ResponseComparator do
 
     context "when the random number from 0-99 is less than the given full_pct" do
       before do
-        allow(described_class).to receive(:rand).with(99).and_return(5)
+        allow(Random).to receive(:rand).with(99).and_return(5)
       end
 
       it "returns true" do
@@ -293,7 +293,7 @@ RSpec.describe ResponseComparator do
 
     context "when the random number from 0-99 is greater than the given full_pct" do
       before do
-        allow(described_class).to receive(:rand).with(99).and_return(25)
+        allow(Random).to receive(:rand).with(99).and_return(25)
       end
 
       it "returns false" do
@@ -302,7 +302,7 @@ RSpec.describe ResponseComparator do
     end
 
     it "adds :r and :sample_percent keys to the given comparison" do
-      allow(described_class).to receive(:rand).with(99).and_return(26)
+      allow(Random).to receive(:rand).with(99).and_return(26)
       obj = {}
       described_class.full_comparison?(obj, 10)
       expect(obj[:r]).to eq(26)

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -201,8 +201,10 @@ RSpec.describe ResponseComparator do
           end
         end
 
-        context "when given a type of :quick" do
-          let(:return_value) { described_class.compare(primary_response, secondary_response, :quick) }
+        context "when it's not a full_comparison" do
+          before do
+            allow(described_class).to receive(:full_comparison?).and_return(false)
+          end
 
           it "does not call different_keys" do
             expect(described_class).not_to receive(:different_keys)
@@ -227,8 +229,10 @@ RSpec.describe ResponseComparator do
           end
         end
 
-        context "when given a type of :full" do
-          let(:return_value) { described_class.compare(primary_response, secondary_response, :full) }
+        context "when it is a full_comparison" do
+          before do
+            allow(described_class).to receive(:full_comparison?).and_return(true)
+          end
 
           it "calls different_keys" do
             expect(described_class).to receive(:different_keys)
@@ -271,6 +275,38 @@ RSpec.describe ResponseComparator do
           end
         end
       end
+    end
+  end
+
+  describe ".full_comparison?" do
+    let(:comparison) { {} }
+
+    context "when the random number from 0-99 is less than the given full_pct" do
+      before do
+        allow(described_class).to receive(:rand).with(99).and_return(5)
+      end
+
+      it "returns true" do
+        expect(described_class.full_comparison?(comparison, 10)).to eq(true)
+      end
+    end
+
+    context "when the random number from 0-99 is greater than the given full_pct" do
+      before do
+        allow(described_class).to receive(:rand).with(99).and_return(25)
+      end
+
+      it "returns false" do
+        expect(described_class.full_comparison?(comparison, 10)).to eq(false)
+      end
+    end
+
+    it "adds :r and :sample_percent keys to the given comparison" do
+      allow(described_class).to receive(:rand).with(99).and_return(26)
+      obj = {}
+      described_class.full_comparison?(obj, 10)
+      expect(obj[:r]).to eq(26)
+      expect(obj[:sample_percent]).to eq(10)
     end
   end
 

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -6,6 +6,33 @@ require "spec_helper"
 require "response_comparator"
 
 RSpec.describe ResponseComparator do
+  subject(:comparator) { described_class.new(primary_response, secondary_response, full_comparison_pct) }
+
+  let(:full_comparison_pct) { 0 }
+  let(:primary_response_body) { "primary response body" }
+  let(:secondary_response_body) { "secondary response body" }
+
+  let(:primary_response) do
+    instance_double(Faraday::Response, {
+      body: primary_response_body,
+      status: 200,
+      headers: {
+        "X-Response-Time" => 123.456,
+        "Content-type" => "text/plain",
+      },
+    })
+  end
+  let(:secondary_response) do
+    instance_double(Faraday::Response, {
+      body: secondary_response_body,
+      status: 200,
+      headers: {
+        "X-Response-Time" => 456.789,
+        "Content-type" => "text/plain",
+      },
+    })
+  end
+
   describe ".response_stats" do
     context "when given a response" do
       let(:response) do
@@ -21,7 +48,7 @@ RSpec.describe ResponseComparator do
       end
 
       describe "the returned value" do
-        let(:result) { described_class.response_stats(response) }
+        let(:result) { comparator.response_stats(response) }
 
         it "is a Hash" do
           expect(result).to be_a(Hash)
@@ -45,7 +72,7 @@ RSpec.describe ResponseComparator do
   describe ".first_difference" do
     context "when given two strings" do
       let(:string1) { "a string of length 20" }
-      let(:return_value) { described_class.first_difference(string1, string2) }
+      let(:return_value) { comparator.first_difference(string1, string2) }
 
       context "with the same value" do
         let(:string2) { string1.dup }
@@ -103,7 +130,7 @@ RSpec.describe ResponseComparator do
       let(:string2) { { a: "a", b: "different b", c: ["c1", "different c2"] }.to_json }
 
       it "returns an array of the keys with different values" do
-        expect(described_class.different_keys(string1, string2)).to eq(%w[b c])
+        expect(comparator.different_keys(string1, string2)).to eq(%w[b c])
       end
 
       context "when the only difference is in :updated_at" do
@@ -113,19 +140,15 @@ RSpec.describe ResponseComparator do
           let(:string2) { { a: "a", b: "b", updated_at: "2023-06-01T08:00:02Z" }.to_json }
 
           it "returns an empty array" do
-            expect(described_class.different_keys(string1, string2)).to be_empty
+            expect(comparator.different_keys(string1, string2)).to be_empty
           end
         end
 
         context "and the difference is more than max_updated_at_difference" do
-          let(:string2) { { a: "a", b: "b", updated_at: "2023-06-01T08:00:03Z" }.to_json }
-
-          before do
-            allow(described_class).to receive(:max_updated_at_difference).and_return(1)
-          end
+          let(:string2) { { a: "a", b: "b", updated_at: "2023-06-01T08:00:11Z" }.to_json }
 
           it "returns an array containing updated_at" do
-            expect(described_class.different_keys(string1, string2)).to eq(%w[updated_at])
+            expect(comparator.different_keys(string1, string2)).to eq(%w[updated_at])
           end
         end
       end
@@ -135,7 +158,7 @@ RSpec.describe ResponseComparator do
         let(:string2) { { a: "a", b: "different b", updated_at: "2023-06-01T08:00:05Z" }.to_json }
 
         it "returns an array containing updated_at and the other different field" do
-          expect(described_class.different_keys(string1, string2)).to eq(%w[b updated_at])
+          expect(comparator.different_keys(string1, string2)).to eq(%w[b updated_at])
         end
       end
     end
@@ -145,134 +168,95 @@ RSpec.describe ResponseComparator do
       let(:string2) { "not json either" }
 
       it "does not error" do
-        expect { described_class.different_keys(string1, string2) }.not_to raise_error
+        expect { comparator.different_keys(string1, string2) }.not_to raise_error
       end
 
       it "returns N/A" do
-        expect(described_class.different_keys(string1, string2)).to eq("N/A")
+        expect(comparator.different_keys(string1, string2)).to eq("N/A")
       end
     end
   end
 
   describe ".compare" do
-    context "when given a primary_response and a secondary_response" do
-      let(:primary_response) do
-        instance_double(Faraday::Response, {
-          body: "primary response body",
-        })
-      end
-      let(:secondary_response) do
-        instance_double(Faraday::Response, {
-          body: "secondary response body",
-        })
+    describe "the return value" do
+      let(:return_value) { comparator.compare }
+
+      it "is a Hash" do
+        expect(return_value).to be_a(Hash)
       end
 
-      describe "the return value" do
-        let(:return_value) { described_class.compare(primary_response, secondary_response) }
+      it "has a primary_response key" do
+        expect(return_value.keys).to include(:primary_response)
+      end
 
-        before do
-          allow(described_class).to receive(:response_stats).with(primary_response).and_return("mock primary response stats")
-          allow(described_class).to receive(:response_stats).with(secondary_response).and_return("mock secondary response stats")
-          allow(described_class).to receive(:different_keys).and_return([])
-          allow(described_class).to receive(:first_difference).and_return("N/A")
+      describe "the primary_response key" do
+        let(:primary_response_key) { return_value[:primary_response] }
+
+        it "is set to the response_stats for the primary_response" do
+          expect(primary_response_key).to eq({ body_size: 21, status: 200, time: 123.456 })
         end
+      end
 
-        it "is a Hash" do
-          expect(return_value).to be_a(Hash)
+      describe "the secondary_response key" do
+        let(:secondary_response_key) { return_value[:secondary_response] }
+
+        it "is set to the response_stats for the secondary_response" do
+          expect(secondary_response_key).to eq({ body_size: 23, status: 200, time: 456.789 })
         end
+      end
 
-        it "has a primary_response key" do
-          expect(return_value.keys).to include(:primary_response)
-        end
+      context "when it's not a full_comparison" do
+        let(:full_comparison_pct) { 0 }
 
-        describe "the primary_response key" do
-          let(:primary_response_key) { return_value[:primary_response] }
-
-          it "is set to the response_stats for the primary_response" do
-            expect(primary_response_key).to eq("mock primary response stats")
+        describe "the different_keys key" do
+          it "is 'N/A'" do
+            expect(return_value[:different_keys]).to eq("N/A")
           end
         end
 
-        describe "the secondary_response key" do
-          let(:secondary_response_key) { return_value[:secondary_response] }
+        describe "the first_difference key" do
+          it "is 'N/A'" do
+            expect(return_value[:first_difference]).to eq("N/A")
+          end
+        end
+      end
 
-          it "is set to the response_stats for the secondary_response" do
-            expect(secondary_response_key).to eq("mock secondary response stats")
+      context "when it is a full_comparison" do
+        let(:full_comparison_pct) { 100 }
+
+        let(:primary_response_body) { { a: "a", b: "b", c: "c" }.to_json }
+        let(:secondary_response_body) { { a: "a", b: "b", z: "z" }.to_json }
+
+        describe "the different_keys key" do
+          it "is set to the names of keys which differ" do
+            expect(return_value[:different_keys]).to eq(%w[c z])
           end
         end
 
-        context "when it's not a full_comparison" do
-          before do
-            allow(described_class).to receive(:full_comparison?).and_return(false)
+        describe "the first_difference key" do
+          let(:first_difference) { "first diff" }
+
+          it "is a Hash" do
+            expect(return_value[:first_difference]).to be_a(Hash)
           end
 
-          it "does not call different_keys" do
-            expect(described_class).not_to receive(:different_keys)
-            return_value
-          end
-
-          describe "the different_keys key" do
-            it "is 'N/A'" do
-              expect(return_value[:different_keys]).to eq("N/A")
+          describe "position key" do
+            it "is set to the index of the first difference" do
+              expect(return_value[:first_difference][:position]).to eq(18)
             end
           end
 
-          it "does not call first_difference" do
-            expect(described_class).not_to receive(:first_difference)
-            return_value
-          end
-
-          describe "the first_difference key" do
-            it "is 'N/A'" do
-              expect(return_value[:first_difference]).to eq("N/A")
+          describe "context key" do
+            it "has 5 characters each side of the position" do
+              expect(return_value[:first_difference][:context]).to eq(["\"b\",\"c\":\"c\"", "\"b\",\"z\":\"z\""])
             end
           end
         end
+      end
 
-        context "when it is a full_comparison" do
-          before do
-            allow(described_class).to receive(:full_comparison?).and_return(true)
-          end
-
-          it "calls different_keys" do
-            expect(described_class).to receive(:different_keys)
-            return_value
-          end
-
-          describe "the different_keys key" do
-            let(:different_keys) { %w[key1 key2] }
-
-            before do
-              allow(described_class).to receive(:different_keys).and_return(different_keys)
-            end
-
-            it "is set to the return value of different_keys" do
-              expect(return_value[:different_keys]).to eq(different_keys)
-            end
-          end
-
-          it "calls first_difference" do
-            expect(described_class).to receive(:first_difference)
-            return_value
-          end
-
-          describe "the first_difference key" do
-            let(:first_difference) { "first diff" }
-
-            before do
-              allow(described_class).to receive(:first_difference).and_return(first_difference)
-            end
-
-            it "is set to the return value of first_difference" do
-              expect(return_value[:first_difference]).to eq(first_difference)
-            end
-          end
-        end
-
-        describe "the response_comparison_seconds key" do
-          it "is a non-zero float" do
-            expect(return_value[:comparison_time_seconds]).to be > 0.00
-          end
+      describe "the response_comparison_seconds key" do
+        it "is a non-zero float" do
+          expect(return_value[:comparison_time_seconds]).to be > 0.00
         end
       end
     end
@@ -287,7 +271,7 @@ RSpec.describe ResponseComparator do
       end
 
       it "returns true" do
-        expect(described_class.full_comparison?(comparison, 10)).to eq(true)
+        expect(comparator.full_comparison?(comparison, 10)).to eq(true)
       end
     end
 
@@ -297,14 +281,14 @@ RSpec.describe ResponseComparator do
       end
 
       it "returns false" do
-        expect(described_class.full_comparison?(comparison, 10)).to eq(false)
+        expect(comparator.full_comparison?(comparison, 10)).to eq(false)
       end
     end
 
     it "adds :r and :sample_percent keys to the given comparison" do
       allow(Random).to receive(:rand).with(99).and_return(26)
       obj = {}
-      described_class.full_comparison?(obj, 10)
+      comparator.full_comparison?(obj, 10)
       expect(obj[:r]).to eq(26)
       expect(obj[:sample_percent]).to eq(10)
     end
@@ -319,7 +303,7 @@ RSpec.describe ResponseComparator do
         let(:max_diff) { 3 }
 
         it "returns true" do
-          expect(described_class.timestamps_close_enough(string1, string2, max_diff)).to eq(true)
+          expect(comparator.timestamps_close_enough(string1, string2, max_diff)).to eq(true)
         end
       end
 
@@ -327,7 +311,7 @@ RSpec.describe ResponseComparator do
         let(:max_diff) { 1 }
 
         it "returns false" do
-          expect(described_class.timestamps_close_enough(string1, string2, max_diff)).to eq(false)
+          expect(comparator.timestamps_close_enough(string1, string2, max_diff)).to eq(false)
         end
       end
     end
@@ -337,7 +321,7 @@ RSpec.describe ResponseComparator do
       let(:string2) { "2023-08-24 66:88:99" }
 
       it "returns false" do
-        expect(described_class.timestamps_close_enough(string1, string2, 2)).to eq(false)
+        expect(comparator.timestamps_close_enough(string1, string2, 2)).to eq(false)
       end
     end
   end

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -209,14 +209,14 @@ RSpec.describe ResponseComparator do
         let(:full_comparison_pct) { 0 }
 
         describe "the different_keys key" do
-          it "is 'N/A'" do
-            expect(return_value[:different_keys]).to eq("N/A")
+          it "is not present" do
+            expect(return_value.keys).not_to include(:different_keys)
           end
         end
 
         describe "the first_difference key" do
-          it "is 'N/A'" do
-            expect(return_value[:first_difference]).to eq("N/A")
+          it "is not present" do
+            expect(return_value.keys).not_to include(:first_difference)
           end
         end
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/sv4yzHj4/865-fix-problem-of-full-comparison-log-lines-from-the-content-store-proxy-not-appearing-in-logit)
After deploying #43 at around 17:45 on Friday 6th, we saw a steady percentage of fully-compared responses for a while, but  zero since `8 Oct, 2023 @ 00:15:02` on integration, and since `7 Oct, 2023 @ 00:15:03` on staging.

On investigation, it looks like fully-compared lines do get generated, but they don't make it into Logit. It seems Logit is refusing to parse them - probably due to a conflicting format with the (more-prevalent) "N/A" string-valued quick comparison lines. 

The cut off at 00:15 on successive nights suggests that either Logit updated their code, or (more likely) that some overnight job is being run to update index patterns and infer field formats from log entries, and the first entry it came across was a quick comparison with string-values. All subsequent lines with structured values (i.e. full comparison) are then rejected as invalid. 

So this PR:

* Removes the `first_difference` & `different_keys` fields entirely when only doing a quick comparison
* Also logs the randomly-generated number & the configured sample percentage
* Refactors the calculation out of the app and into the `ResponseComparator` object to make this simpler
* Refactors the `ResponseComparator` to use an instance with attributes, rather than stateless class methods. This makes for simpler code, as many of the method arguments can now be removed.

I've deployed this branch to integration, and we can see that the full-comparison lines are now making it into Logit again:
 
![Screenshot from 2023-10-10 08-41-46](https://github.com/alphagov/content-store-proxy/assets/134501/b3ba7007-befe-4bf2-b776-ed905301e614)


This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
