### PR TITLE
Fix issue with incorrectly logging a warning when `:different_keys` is an empty array

### DIFF
--- a/lib/comparison_logger.rb
+++ b/lib/comparison_logger.rb
@@ -1,0 +1,34 @@
+class ComparisonLogger
+  def self.log(comparison, request)
+    puts line(comparison, request)
+  end
+
+  def self.line(comparison, request)
+    log_structure(comparison, request).to_json
+  end
+
+  def self.log_structure(comparison, request)
+    {
+      timestamp: Time.now.utc.iso8601,
+      level: log_level(comparison),
+      method: request.env["REQUEST_METHOD"],
+      path: request.path,
+      query_string: request.env["QUERY_STRING"],
+      stats: comparison,
+    }
+  end
+
+  def self.log_level(comparison)
+    if (comparison[:different_keys].nil? || comparison[:different_keys] == [] || comparison[:different_keys] == "N/A") &&
+        matches?(comparison, :status) &&
+        matches?(comparison, :body_size)
+      :info
+    else
+      :warn
+    end
+  end
+
+  def self.matches?(comparison, field)
+    comparison.dig(:primary_response, field) == comparison.dig(:secondary_response, field)
+  end
+end

--- a/spec/lib/comparison_logger_spec.rb
+++ b/spec/lib/comparison_logger_spec.rb
@@ -1,0 +1,135 @@
+require "sinatra/base"
+
+require "spec_helper"
+require "comparison_logger"
+
+RSpec.describe ComparisonLogger do
+  let(:primary_response_status) { 201 }
+  let(:secondary_response_status) { 201 }
+  let(:primary_response_body_size) { 22_222 }
+  let(:secondary_response_body_size) { 22_222 }
+  let(:different_keys) { nil }
+  let(:first_difference) { nil }
+
+  let(:comparison) do
+    {
+      primary_response: {
+        status: primary_response_status,
+        body_size: primary_response_body_size,
+        time: 0.001045556,
+      },
+      secondary_response: {
+        status: secondary_response_status,
+        body_size: secondary_response_body_size,
+        time: 0.000890302,
+      },
+      different_keys:,
+      first_difference:,
+      sample_percent: 0,
+      r: 51,
+      comparison_time_seconds: 1.9445e-05,
+    }
+  end
+  let(:mock_env) { { "REQUEST_METHOD" => "GET", "QUERY_STRING" => "abc=123" } }
+  let(:mock_request) { instance_double(Sinatra::Request, env: mock_env, path: "/api/content/") }
+
+  describe ".log" do
+    it "logs the generated line to STDOUT" do
+      expect { described_class.log(comparison, mock_request) }.to output.to_stdout
+    end
+  end
+
+  describe ".log_structure" do
+    context "when given a comparison and a request" do
+      describe "the result" do
+        let(:result) { described_class.log_structure(comparison, mock_request) }
+
+        it "is a Hash" do
+          expect(result).to be_a(Hash)
+        end
+
+        it "has a timestamp" do
+          expect(result[:timestamp]).not_to be_nil
+        end
+
+        it "has a level " do
+          expect(result[:level]).not_to be_nil
+        end
+
+        it "has a method set to the request method" do
+          expect(result[:method]).to eq("GET")
+        end
+
+        it "has path set to the request path" do
+          expect(result[:path]).to eq("/api/content/")
+        end
+
+        it "has query_string set to the request query string" do
+          expect(result[:query_string]).to eq("abc=123")
+        end
+
+        it "has stats set to the given comparison" do
+          expect(result[:stats]).to eq(comparison)
+        end
+      end
+    end
+  end
+
+  shared_examples_for described_class do
+    let(:result) { described_class.log_level(comparison) }
+
+    context "when the status of the two responses matches" do
+      let(:primary_response_status) { 401 }
+      let(:secondary_response_status) { 401 }
+
+      context "when the body_size of the two responses matches" do
+        let(:primary_response_body_size) { 12_345 }
+        let(:secondary_response_body_size) { 12_345 }
+
+        it "returns :info" do
+          expect(result).to eq(:info)
+        end
+      end
+
+      context "when the body_size of the two responses does not match" do
+        let(:primary_response_body_size) { 12_345 }
+        let(:secondary_response_body_size) { 23_456 }
+
+        it "returns :warn" do
+          expect(result).to eq(:warn)
+        end
+      end
+    end
+
+    context "when the status of the two responses does not match" do
+      let(:primary_response_status) { 401 }
+      let(:secondary_response_status) { 403 }
+
+      it "returns :warn" do
+        expect(result).to eq(:warn)
+      end
+    end
+  end
+
+  describe ".log_level" do
+    context "when given a comparison" do
+      context "with :different_keys set to nil" do
+        let(:different_keys) { nil }
+
+        it_behaves_like described_class
+      end
+
+      context "with :different_keys set to []" do
+        let(:different_keys) { [] }
+
+        it_behaves_like described_class
+      end
+
+      context "with :different_keys set to 'N/A'" do
+        let(:different_keys) { "N/A" }
+
+        it_behaves_like described_class
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Fix issue with incorrectly logging a warning when `:different_keys` is an empty array
* Refactor log decision points into a standalone object, to make it more testable
* Add tests for the new `ComparisonLogger` object

Part of [this Trello card](https://trello.com/c/sv4yzHj4/865-fix-problem-of-full-comparison-log-lines-from-the-content-store-proxy-not-appearing-in-logit)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
