### PR TITLE
speed up first_difference method by ~1000x on large response bodies

### DIFF
--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -57,11 +57,11 @@ class ResponseComparator
     # at the start of string2
     # Almost 1000 times faster for long strings (>250k characters)
     # on local testing when compared to naive iterate-and-compare-each-char
-    i = (0..string1.length).bsearch { |i| string2.rindex(string1[0..i]) != 0 }
+    i = (0..string1.length).bsearch { |n| string2.rindex(string1[0..n]) != 0 }
 
     # Just need to handle the edge case where string2 is string1 + some stuff on the end
-    if i.nil?
-      i = string1.length if string2.length > string1.length
+    if i.nil? && (string2.length > string1.length)
+      i = string1.length
     end
 
     i.nil? ? {} : { position: i, context: [string1[i - 5..i + 5], string2[i - 5..i + 5]] }

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -53,12 +53,18 @@ class ResponseComparator
   end
 
   def first_difference(string1, string2)
-    if string1 == string2
-      {}
-    else
-      i = (0...string1.size).find { |j| string1[j] != string2[j] } || string1.size
-      { position: i, context: [string1[i - 5..i + 5], string2[i - 5..i + 5]] }
+    # Binary search to find the first index where the slice of string1 is not
+    # at the start of string2
+    # Almost 1000 times faster for long strings (>250k characters)
+    # on local testing when compared to naive iterate-and-compare-each-char
+    i = (0..string1.length).bsearch { |i| string2.rindex(string1[0..i]) != 0 }
+
+    # Just need to handle the edge case where string2 is string1 + some stuff on the end
+    if i.nil?
+      i = string1.length if string2.length > string1.length
     end
+
+    i.nil? ? {} : { position: i, context: [string1[i - 5..i + 5], string2[i - 5..i + 5]] }
   end
 
   def different_keys(json_hash1, json_hash2)

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ResponseComparator do
 
   describe ".first_difference" do
     context "when given two strings" do
-      let(:string1) { "a string of length 20" }
+      let(:string1) { "a string of length 21" }
       let(:return_value) { comparator.first_difference(string1, string2) }
 
       context "with the same value" do
@@ -92,7 +92,7 @@ RSpec.describe ResponseComparator do
         end
 
         context "and the difference is more than 5 characters from the start and more than 5 characters from the end" do
-          let(:string2) { "a string!of length 20" }
+          let(:string2) { "a string!of length 21" }
 
           describe "the return value" do
             it "has :context set to the 5 characters either side of the first difference, from each string" do
@@ -102,21 +102,49 @@ RSpec.describe ResponseComparator do
         end
 
         context "and the difference is more than 5 characters from the start and less than 5 characters from the end" do
-          let(:string2) { "a string of length!20" }
+          let(:string2) { "a string of length!21" }
 
           describe "the return value" do
             it "has :context set to the 5 characters before the first difference, and only up to the end of each string" do
-              expect(return_value[:context]).to eq(["ength 20", "ength!20"])
+              expect(return_value[:context]).to eq(["ength 21", "ength!21"])
             end
           end
         end
 
         context "and the difference is less than 5 characters from the start and more than 5 characters from the end" do
-          let(:string2) { "a string of length!20" }
+          let(:string2) { "a string of length!21" }
 
           describe "the return value" do
             it "has :context set to the available characters before the first difference, and the 5 characters after each string" do
-              expect(return_value[:context]).to eq(["ength 20", "ength!20"])
+              expect(return_value[:context]).to eq(["ength 21", "ength!21"])
+            end
+          end
+        end
+
+        context "and the difference is after the end of string1" do
+          let(:string2) { string1 + "!" }
+
+          describe "the return value" do
+            it "has :position set to the position of the first difference" do
+              expect(return_value[:position]).to eq(21)
+            end
+
+            it "has :context set to the 5 characters either side of the first difference, from each string" do
+              expect(return_value[:context]).to eq(["th 21", "th 21!"])
+            end
+          end
+        end
+
+        context "and the difference is after the end of string2" do
+          let(:string1) { string2 + "!" }
+
+          describe "the return value" do
+            it "has :position set to the position of the first difference" do
+              expect(return_value[:position]).to eq(18)
+            end
+
+            it "has :context set to the 5 characters either side of the first difference, from each string" do
+              expect(return_value[:context]).to eq(["tring!", "tring"])
             end
           end
         end

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ResponseComparator do
         end
 
         context "and the difference is after the end of string1" do
-          let(:string2) { string1 + "!" }
+          let(:string2) { "#{string1}!" }
 
           describe "the return value" do
             it "has :position set to the position of the first difference" do
@@ -136,7 +136,7 @@ RSpec.describe ResponseComparator do
         end
 
         context "and the difference is after the end of string2" do
-          let(:string1) { string2 + "!" }
+          let(:string1) { "#{string2}!" }
 
           describe "the return value" do
             it "has :position set to the position of the first difference" do


### PR DESCRIPTION
…by using a binary search, rather than a naive iterate-and-compare-each-char. ([Trello card](https://trello.com/c/gF3XSEqC/864-reduce-the-cpu-load-imposed-by-content-store-proxy))

Before:
```
# Using the body of /api/content/foreign-travel-advice -  
> body1.size
=> 311974

# Change one randomly-positioned character, and find the first_difference:
> Benchmark.measure{ 10.times{ body2 = body1.dup; body2[rand(body2.size - 1)] = '?'; rc.first_difference(body1, body3) } }
=> #<Benchmark::Tms:0x00007f6559a198f0 @cstime=0.0, @cutime=0.0, @label="", @real=46.78253520699218, @stime=0.0, @total=46.74067100000002, @utime=46.74067100000002>
```
So originally, 46 seconds to do this 10 times.

After:
```
Benchmark.measure{ 10.times{ body3 = body1.dup; body3[rand(body3.size - 1)] = '?'; rc.first_difference(body1, body3) } }
=> #<Benchmark::Tms:0x00007f6559c72750 @cstime=0.0, @cutime=0.0, @label="", @real=0.04551295703276992, @stime=1.9999999998354667e-06, @total=0.045513000000033, @utime=0.045511000000033164>
```
*0.046s*

Credit to [this StackOverflow answer](https://stackoverflow.com/a/31714818) for the idea - thanks [Kranzky](https://stackoverflow.com/users/5442/kranzky)! 

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
