### PR TITLE
Stop warning about minor differences in scheduled_publishing_delay_seconds

### DIFF
--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -353,4 +353,40 @@ RSpec.describe ResponseComparator do
       end
     end
   end
+
+  describe ".integers_close_enough" do
+    context "when given two valid integers" do
+      let(:int1) { 123 }
+      let(:int2) { 125 }
+
+      context "and they differ by less than max_diff seconds" do
+        let(:max_diff) { 3 }
+
+        it "returns true" do
+          expect(comparator.integers_close_enough(int1, int2, max_diff)).to eq(true)
+        end
+      end
+
+      context "and they differ by more than max_diff seconds" do
+        let(:max_diff) { 1 }
+
+        it "returns false" do
+          expect(comparator.integers_close_enough(int1, int2, max_diff)).to eq(false)
+        end
+      end
+    end
+
+    context "when given two values which are not both valid integers" do
+      let(:int1) { nil }
+      let(:int2) { "a lizard" }
+
+      it "does not raise an error" do
+        expect { comparator.integers_close_enough(int1, int2, 2) }.not_to raise_error
+      end
+
+      it "returns false" do
+        expect(comparator.integers_close_enough(int1, int2, 2)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/COOOKMEv/879-stop-content-store-proxy-warning-about-small-1-2s-differences-in-scheduledpublishingdelayseconds) - it's quite possible and acceptable for the values of `scheduled_publishing_delay_seconds` to differ by 1 or even 2 seconds between the two databases, as this value is calculated by the content store when the content_item is saved.

This PR stops it logging a warning if the two values for `scheduled_publishing_delay_seconds` are within 2s of each other.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
