### PR TITLE
Only warn about 303 response differences if the path in the location header differs

### DIFF
--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -47,11 +47,13 @@ class ResponseComparator
   end
 
   def response_stats(response)
-    {
+    stats = {
       status: response.status,
       body_size: response.body.size,
       time: response.headers["X-Response-Time"].to_f,
     }
+    stats.merge!(location: response.headers["Location"]) if response.status == 303
+    stats
   end
 
   def first_difference(string1, string2)

--- a/spec/lib/comparison_logger_spec.rb
+++ b/spec/lib/comparison_logger_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ComparisonLogger do
   let(:secondary_response_body_size) { 22_222 }
   let(:different_keys) { nil }
   let(:first_difference) { nil }
+  let(:primary_response_location) { nil }
+  let(:secondary_response_location) { nil }
 
   let(:comparison) do
     {
@@ -17,11 +19,13 @@ RSpec.describe ComparisonLogger do
         status: primary_response_status,
         body_size: primary_response_body_size,
         time: 0.001045556,
+        location: primary_response_location,
       },
       secondary_response: {
         status: secondary_response_status,
         body_size: secondary_response_body_size,
         time: 0.000890302,
+        location: secondary_response_location,
       },
       different_keys:,
       first_difference:,
@@ -95,8 +99,33 @@ RSpec.describe ComparisonLogger do
         let(:primary_response_body_size) { 12_345 }
         let(:secondary_response_body_size) { 23_456 }
 
-        it "returns :warn" do
-          expect(result).to eq(:warn)
+        context "when the statuses are both 303" do
+          let(:primary_response_status) { 303 }
+          let(:secondary_response_status) { 303 }
+
+          context "when the locations have the same path" do
+            let(:primary_response_location) { "http://content-store-mongo-main/api/content/some-path" }
+            let(:secondary_response_location) { "http://content-store-postgresql-branch/api/content/some-path" }
+
+            it "returns :info" do
+              expect(result).to eq(:info)
+            end
+          end
+
+          context "when the locations do not have the same path" do
+            let(:primary_response_location) { "http://content-store-mongo-main/api/content/some-path" }
+            let(:secondary_response_location) { "http://content-store-mongo-main/api/content/some-other-path" }
+
+            it "returns :warn" do
+              expect(result).to eq(:warn)
+            end
+          end
+        end
+
+        context "when the statuses are not both 303" do
+          it "returns :warn" do
+            expect(result).to eq(:warn)
+          end
         end
       end
     end


### PR DESCRIPTION
[Trello card](https://trello.com/c/FT5dFGSM/880-stop-content-store-proxy-warning-about-differences-in-the-body-of-a-303-redirect)

When the content stores return a 303 redirect, two specific things happen which we need to account for:

1. They return a `Location` header with a fully-scoped URL, containing their own hostname (eg. `http://content-store-mongo-main/api/content/some-path`). This is nothing to worry about, as the host is replaced with the public-facing domain name further up the stack and is never returned to the users's browser. The only user-affecting part of a 303 response is the _path_ of the `Location` 
2. They auto-generate a HTML response body (regardless of incoming `Content-type` or `Accept` headers) like this:
```
<html><body>You are being <a href="http://content-store-mongo-main/api/content/healthcare-immigration-application">redirected</a>.</body></html>
```

As the link contains the content-store hostname, that causes a difference between the two responses, and means that every fully-compared 303 is logged as a warning, even though the only thing that really matters is the relative path of the URL in the `Location` header.

This PR adds a special case for 303 responses, and in those cases will only warn if the path of the `Location` header differs.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
