### PR TITLE
Add an optional timeout on the secondary_response

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ It will forward all incoming requests to the given `PRIMARY_UPSTREAM` and `SECON
 
 Any errors on the secondary response are ignored and do not interfere with the primary response.
 
+## Secondary response timeouts
+
+As the secondary response is never served to the user, but the proxy has to wait for both responses to complete before it can compare them, it's possible that a very slow secondary upstream can still lead to downstream ill-effects. 
+
+So a timeout can be set on the secondary response only, using the environment variable `SECONDARY_TIMEOUT_SECONDS=(float or integer)`.  If the secondary response takes longer than this many seconds,
+it will be ignored, and logged as `"secondary_response": null`, with a log level of `"info"`. 
+
 ## Detailed Response Comparison and CPU-load
 
 Note: comparing the responses is CPU-intensive, and so must be used with care on highly-contended environments like production. For a given percentage of requests, a full comparison will be run which will populate the `first_difference` and `different_keys` keys. The percentage is controlled by the environment variable `COMPARISON_SAMPLE_PCT`. The default value for this is `0` - to compare, say, one in ten requests you would supply `COMPARISON_SAMPLE_PCT=10`.

--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -21,7 +21,7 @@ class ResponseComparator
   def compare
     start = Time.now
     comparison = quick_comparison
-    comparison.merge!(differences) if full_comparison?(comparison, full_comparison_pct)
+    comparison.merge!(differences) if @secondary_response && full_comparison?(comparison, full_comparison_pct)
     comparison[:comparison_time_seconds] = Time.now - start
     comparison
   end
@@ -29,7 +29,7 @@ class ResponseComparator
   def quick_comparison
     {
       primary_response: response_stats(@primary_response),
-      secondary_response: response_stats(@secondary_response),
+      secondary_response: @secondary_response ? response_stats(@secondary_response) : nil,
     }
   end
 

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -231,6 +231,14 @@ RSpec.describe ResponseComparator do
         it "is set to the response_stats for the secondary_response" do
           expect(secondary_response_key).to eq({ body_size: 23, status: 200, time: 456.789 })
         end
+
+        context "when the secondary_response is nil" do
+          let(:secondary_response) { nil }
+
+          it "is nil" do
+            expect(secondary_response_key).to be_nil
+          end
+        end
       end
 
       context "when it's not a full_comparison" do
@@ -277,6 +285,22 @@ RSpec.describe ResponseComparator do
           describe "context key" do
             it "has 5 characters each side of the position" do
               expect(return_value[:first_difference][:context]).to eq(["\"b\",\"c\":\"c\"", "\"b\",\"z\":\"z\""])
+            end
+          end
+        end
+
+        context "but the secondary_response is nil" do
+          let(:secondary_response) { nil }
+
+          describe "the different_keys key" do
+            it "is not present" do
+              expect(return_value.keys).not_to include(:different_keys)
+            end
+          end
+
+          describe "the first_difference key" do
+            it "is not present" do
+              expect(return_value.keys).not_to include(:first_difference)
             end
           end
         end


### PR DESCRIPTION
Full context on this [Trello card](https://trello.com/c/xse8nT4S/913-add-a-timeout-to-the-secondary-response-in-content-store-proxy)

Whilst we are dual-running on production with MongoDB primary and PostgreSQL secondary, the secondary response is actually inconsequential - it's never served to the user, it's only so that we can compare the responses and build confidence in the equivalence of the two DBs.

However, every morning the MongoDB->PostgreSQL ETL job is run to update the PostgreSQL DB from the MongoDB. It's mostly fine, but it locks the PostgreSQL tables temporarily on completion, as it switches-in the imported rows. On prod that's nearly 1m records, so it locks the tables for up to 2 minutes. 

The proxy forwards the requests to both DBs in parallel, but it still has to wait for both to complete before it can compare the responses and return the primary to the user. This means that a blockage on the PostgreSQL side does still affect primary frontend responses. If requests take longer than the 4s timeout set by the frontends, that results in an error, and Sentry alerts are currently being raised for around 2 mins at around 2.30am each day.

The simplest way to deal with this is just to add a timeout of, say, 2s on the secondary response (the logs show that outside of the 2.30am peak, hardly any requests ever take longer than 1.1s). If the secondary times-out, we don't actually care - it's more important to maintain quality of service on the primary responses, so just stop waiting for it and return the primary response. This should stop the spike at 2.30am.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
