### PR TITLE
Handle all errors on the secondary_response more gracefully

### DIFF
--- a/lib/request_forwarder.rb
+++ b/lib/request_forwarder.rb
@@ -12,8 +12,9 @@ class RequestForwarder
     # forward to secondary upstream
     secondary_thread = Thread.new do
       forward_to(secondary_upstream, incoming_request, payload, timeout: secondary_timeout)
-    rescue Faraday::TimeoutError
-      nil
+    # ...handle timeout errors on the secondary gracefully
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+      e
     end
 
     primary_thread.join


### PR DESCRIPTION
To stop errors on the secondary at the time the Mongo-to-Postgresql cron job completes, from propagating through to the frontend apps and users, we need to handle errors on the secondary response more gracefully.

This PR makes the proxy catch `ConnectionFailed` as well as` TimeoutError`, and rather than logging `nil` for the secondary response, log the error message & type in an `error:` key.

[Trello card](https://trello.com/c/VF0NRwve/916-handle-error-when-content-store-proxy-cant-open-a-connection-to-the-secondary)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
