### PR TITLE
Catch any and all exceptions raised when comparing responses

### DIFF
--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -65,6 +65,27 @@ RSpec.describe "Forwarding service" do
       end
     end
 
+    context "when an error is thrown in comparing the responses" do
+      let(:mock_comparator) { instance_double(ResponseComparator) }
+
+      before do
+        allow(ResponseComparator).to receive(:new).and_return(mock_comparator)
+        allow(mock_comparator).to receive(:compare).and_raise(TypeError, "This exception should be caught by the app")
+      end
+
+      it "does not allow the error to bubble out" do
+        expect {
+          get "/foo"
+        }.not_to raise_error
+      end
+
+      it "still returns the primary status and body" do
+        get "/foo"
+        expect(last_response.status).to eq(primary_response_status)
+        expect(last_response.body).to eq(primary_response_body)
+      end
+    end
+
     context "when the request has headers" do
       let(:headers) { { "HTTP_X_ARBITRARY_HEADER" => "X-A-H header value", "HTTP_ACCEPT" => "application/json" } }
 


### PR DESCRIPTION
- to ensure that the primary response is always returned. [Trello card](https://trello.com/c/ScvwYac3/925-incident-action-rescue-all-exceptions-thrown-in-response-comparison-in-content-store-proxy) and relevant [incident report](https://docs.google.com/document/d/1sg_RNUbEeBPlaBOQG2enkwDX83zGOjtBWlUbFENKLiE/edit)

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
