### PR TITLE
Fix error when comparing an integer to a nil value

### DIFF
--- a/lib/response_comparator.rb
+++ b/lib/response_comparator.rb
@@ -104,7 +104,7 @@ class ResponseComparator
   end
 
   def integers_close_enough(int1, int2, max_diff)
-    (int1 - int2).to_i.abs <= max_diff
+    int1.is_a?(Integer) && int2.is_a?(Integer) && (int1 - int2).to_i.abs <= max_diff
   rescue ArgumentError, NoMethodError
     false
   end

--- a/spec/lib/response_comparator_spec.rb
+++ b/spec/lib/response_comparator_spec.rb
@@ -440,9 +440,35 @@ RSpec.describe ResponseComparator do
       end
     end
 
-    context "when given two values which are not both valid integers" do
+    context "when given two values which are both not valid integers" do
       let(:int1) { nil }
       let(:int2) { "a lizard" }
+
+      it "does not raise an error" do
+        expect { comparator.integers_close_enough(int1, int2, 2) }.not_to raise_error
+      end
+
+      it "returns false" do
+        expect(comparator.integers_close_enough(int1, int2, 2)).to eq(false)
+      end
+    end
+
+    context "when the first value is nil but the second is a valid integer" do
+      let(:int1) { nil }
+      let(:int2) { 0 }
+
+      it "does not raise an error" do
+        expect { comparator.integers_close_enough(int1, int2, 2) }.not_to raise_error
+      end
+
+      it "returns false" do
+        expect(comparator.integers_close_enough(int1, int2, 2)).to eq(false)
+      end
+    end
+
+    context "when the second value is nil but the first is a valid integer" do
+      let(:int2) { nil }
+      let(:int1) { 0 }
 
       it "does not raise an error" do
         expect { comparator.integers_close_enough(int1, int2, 2) }.not_to raise_error


### PR DESCRIPTION
This PR fixes the specific error found in yesterday's [incident](https://docs.google.com/document/d/1sg_RNUbEeBPlaBOQG2enkwDX83zGOjtBWlUbFENKLiE/edit), when `scheduled_publishing_delay_seconds` was nil in the Postgres content-store but an Integer in the MongoDB content-store. *([Trello card](https://trello.com/c/ScvwYac3/925-incident-action-rescue-all-exceptions-thrown-in-response-comparison-in-content-store-proxy))

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.   

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
